### PR TITLE
Deploy 2026-05-01: merge dev → main

### DIFF
--- a/user_profile/templates/mi_fuego/event_admin.html
+++ b/user_profile/templates/mi_fuego/event_admin.html
@@ -183,6 +183,20 @@
                         </div>
                     </div>
 
+                    <!-- Bonos vendidos por día -->
+                    <div class="stats-card mb-4">
+                        <h5 class="mb-3">
+                            <i class="fas fa-chart-bar me-2"></i>
+                            Bonos vendidos por día
+                        </h5>
+                        <p class="text-muted small mb-3">
+                            Cantidad de bonos emitidos por día calendario (zona {{ sales_chart_timezone }}), solo órdenes confirmadas.
+                        </p>
+                        <div class="position-relative" style="min-height: 280px;">
+                            <canvas id="chart-sales-by-day"></canvas>
+                        </div>
+                    </div>
+
                     <!-- Progress Bar for Tickets Sold -->
                     {% if event.max_tickets %}
                         <div class="stats-card">
@@ -430,4 +444,66 @@
             </div>
         </div>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script>
+    (function () {
+        var salesByDay = {{ sales_by_day_chart_json|safe }};
+        var canvas = document.getElementById('chart-sales-by-day');
+        if (!canvas) return;
+        var wrap = canvas.closest('.position-relative');
+        if (!salesByDay.length) {
+            wrap.innerHTML = '<p class="text-muted text-center py-5 mb-0">Todavía no hay ventas de bonos con orden confirmada.</p>';
+            return;
+        }
+        var labels = salesByDay.map(function (d) { return d.label; });
+        var counts = salesByDay.map(function (d) { return d.count; });
+        var dates = salesByDay.map(function (d) { return d.date; });
+        new Chart(canvas, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Bonos',
+                    data: counts,
+                    backgroundColor: 'rgba(40, 158, 109, 0.55)',
+                    borderColor: 'rgb(40, 158, 109)',
+                    borderWidth: 1,
+                    borderRadius: 4,
+                    maxBarThickness: 36
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            title: function (items) {
+                                var i = items[0].dataIndex;
+                                return dates[i] || items[0].label;
+                            },
+                            label: function (ctx) {
+                                var n = ctx.parsed.y;
+                                return n + (n === 1 ? ' bono' : ' bonos');
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        title: { display: true, text: 'Día' },
+                        ticks: { maxRotation: 45, minRotation: 0, autoSkip: true, maxTicksLimit: 31 }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        ticks: { stepSize: 1 },
+                        title: { display: true, text: 'Cantidad de bonos' }
+                    }
+                }
+            }
+        });
+    })();
+    </script>
 {% endblock truecontent %}

--- a/user_profile/templates/mi_fuego/my_tickets/my_ticket.html
+++ b/user_profile/templates/mi_fuego/my_tickets/my_ticket.html
@@ -253,15 +253,6 @@
                 </div>
             </div>
         {% endif %}
-
-        <div class="alert alert-info text-start">
-            <div class="d-flex align-items-center gap-2">
-                <i class="fas fa-info-circle"></i>
-                <div class="flex-grow-1">
-                    <strong>Recomendación importante:</strong> Te recomendamos tomar una captura de pantalla o descargar el bono en PDF, ya que puede no haber buena conexión a internet en el terreno. Podés descargar el bono usando el botón de descarga en cada bono.
-                </div>
-            </div>
-        </div>
             
         {% for ticket in tickets_dto %}
             <div class="card my-4 border" data-ticket-key="{{ ticket.key }}" style="position: relative;">

--- a/user_profile/views.py
+++ b/user_profile/views.py
@@ -1877,12 +1877,16 @@ def event_management_view(request, event_slug):
         
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            # Format datetime fields for HTML5 datetime-local input
+            # Format datetime fields for HTML5 datetime-local input (always "local" wall time,
+            # no TZ suffix). DB values are UTC-aware with USE_TZ; strftime on them would show
+            # UTC clock in the widget while Django parses submitted values in TIME_ZONE — mismatch.
             if self.instance and self.instance.pk:
                 if self.instance.start:
-                    self.initial['start'] = self.instance.start.strftime('%Y-%m-%dT%H:%M')
+                    start_local = timezone.localtime(self.instance.start)
+                    self.initial['start'] = start_local.strftime('%Y-%m-%dT%H:%M')
                 if self.instance.end:
-                    self.initial['end'] = self.instance.end.strftime('%Y-%m-%dT%H:%M')
+                    end_local = timezone.localtime(self.instance.end)
+                    self.initial['end'] = end_local.strftime('%Y-%m-%dT%H:%M')
     
     # Handle form submission
     if request.method == 'POST':

--- a/user_profile/views.py
+++ b/user_profile/views.py
@@ -1295,6 +1295,34 @@ def event_admin_view(request, event_slug):
         payment_method_total_ordenes += ordenes_i
         payment_method_total_bonos += bonos_i
 
+    # Bonos vendidos por día (fecha local del proyecto), órdenes confirmadas
+    from django.db.models import Count
+    from django.db.models.functions import TruncDate
+
+    sales_rows = (
+        NewTicket.objects.filter(
+            event=event,
+            order__status=Order.OrderStatus.CONFIRMED,
+        )
+        .annotate(
+            sale_day=TruncDate(
+                "created_at", tzinfo=timezone.get_current_timezone()
+            )
+        )
+        .values("sale_day")
+        .annotate(bonos=Count("id"))
+        .order_by("sale_day")
+    )
+    sales_by_day_chart = [
+        {
+            "date": row["sale_day"].isoformat(),
+            "label": row["sale_day"].strftime("%d/%m"),
+            "count": row["bonos"],
+        }
+        for row in sales_rows
+        if row["sale_day"] is not None
+    ]
+
     # MercadoPago commission details (match provided SQL: ONLINE_PURCHASE only)
     with connection.cursor() as cursor:
         cursor.execute(
@@ -1519,6 +1547,8 @@ def event_admin_view(request, event_slug):
         },
         # Backward-compat: previous template expected this variable (section is now removed).
         "caja_payment_method_breakdown": [],
+        "sales_by_day_chart_json": json.dumps(sales_by_day_chart),
+        "sales_chart_timezone": settings.TIME_ZONE,
     }
     
     return render(request, "mi_fuego/event_admin.html", context)


### PR DESCRIPTION
## Changelog (dev vs main)

### Reporte de ventas (admin de evento)
- **Gráfico de barras "Bonos vendidos por día"**: histograma diario de cantidad de bonos (`NewTicket`) con orden **CONFIRMED**, agrupado por día calendario en la zona horaria del proyecto (`TIME_ZONE`). Incluye tooltips con fecha y totales; usa Chart.js (misma stack que el dashboard del scanner).

### Configuración del evento
- **Fechas inicio/fin en `datetime-local`**: al mostrar el formulario se usa `timezone.localtime()` antes de formatear, para alinear la UI con `USE_TZ` (antes se usaba la hora UTC en el input y al guardar parecía que los valores "volvían" solos).

### Mi bono / tickets
- **Menos ruido en pantalla**: se quitó el alert permanente que recomendaba captura/PDF por posible mala señal en el terreno.

---

**Archivos:** `user_profile/views.py`, `user_profile/templates/mi_fuego/event_admin.html`, `user_profile/templates/mi_fuego/my_tickets/my_ticket.html`

**Nota:** En el historial de `dev` hay un commit con mensaje erróneo del generador de mensajes; el contenido útil queda reflejado en los commits adyacentes y en este diff neto respecto de `main`.


Made with [Cursor](https://cursor.com)