### PR TITLE
Fix 500 when all events have ended

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -151,15 +151,29 @@ class Event(BaseModel):
 
     @classmethod
     def get_main_event(cls):
-        """Get the main event (displayed at /)"""
+        """Get the main event (displayed at /).
+
+        Prefer a current/upcoming main. If every event has ended, keep showing
+        the last finished active event instead of returning None.
+        """
         from events.services.main_event import reconcile_main_event
 
         reconcile_main_event()
-        return cls.objects.filter(
+        now = timezone.now()
+        current = cls.objects.filter(
             is_main=True,
             active=True,
-            end__gte=timezone.now(),
+            end__gte=now,
         ).first()
+        if current:
+            return current
+
+        # Reconcile keeps an expired main when there is no replacement.
+        expired_main = cls.objects.filter(is_main=True, active=True).first()
+        if expired_main:
+            return expired_main
+
+        return cls.objects.filter(active=True).order_by('-end', '-id').first()
 
     @classmethod
     def get_active_events(cls):

--- a/events/services/main_event.py
+++ b/events/services/main_event.py
@@ -49,7 +49,7 @@ def _transfer_main(*, new_main, previous_main=None):
 def reconcile_main_event():
     """
     Si el main actual no es vigente y hay otro evento activo vigente, pasa el main a ese.
-    Si no hay reemplazo, el main actual queda (get_main_event no lo muestra si ya venció).
+    Si no hay reemplazo, el main actual queda y get_main_event lo sigue mostrando.
     """
     current_main = Event.objects.filter(is_main=True).first()
 

--- a/events/tests.py
+++ b/events/tests.py
@@ -361,7 +361,7 @@ class MainEventRotationTests(TestCase):
         self.assertFalse(old_main.is_main)
         self.assertTrue(replacement.is_main)
 
-    def test_expired_main_without_replacement_is_not_shown_on_home(self):
+    def test_expired_main_without_replacement_is_still_shown_on_home(self):
         now = timezone.now()
         old_main = _make_event(is_main=True, slug='expired-only')
         Event.objects.filter(pk=old_main.pk).update(
@@ -369,7 +369,7 @@ class MainEventRotationTests(TestCase):
             end=now - timedelta(hours=1),
         )
 
-        self.assertIsNone(Event.get_main_event())
+        self.assertEqual(Event.get_main_event().pk, old_main.pk)
 
     def test_inactive_main_rotates_to_other_active_event(self):
         now = timezone.now()

--- a/utils/context_processors.py
+++ b/utils/context_processors.py
@@ -33,8 +33,7 @@ def current_event(request):
         "event": event,
         "has_multiple_events": has_multiple_events,
     }
-    if request.user.is_authenticated:
-
+    if request.user.is_authenticated and event:
         tickets = NewTicket.objects.filter(
             holder=request.user, event=event
         ).all()
@@ -65,7 +64,6 @@ def current_event(request):
             ).count()
         else:
             holding_tickets = len(tickets)
-
 
         # Count total tickets across all active events
         total_tickets = NewTicket.objects.filter(


### PR DESCRIPTION
## Summary
- After every event ends, `get_main_event()` returned `None` and the global context processor crashed for logged-in users (`AttributeError` on `attendee_must_be_registered`).
- Keep showing the last finished main/active event instead of a 500.
- Guard the context processor when `event` is missing.

Same fix as #302 (against `dev`), cherry-picked onto `main` for a production hotfix path.

## Test plan
- [ ] With only an expired main event, visit `/` logged in → page loads (no 500) and shows that event
- [ ] With a current/upcoming main, home still shows the current main
- [ ] With an expired main + a newer active event, rotation still promotes the replacement
- [ ] `python manage.py test events.tests.MainEventRotationTests --keepdb`


Made with [Cursor](https://cursor.com)